### PR TITLE
Specify target directory for install script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-cargo build --release
+cargo build --release --target-dir ./target
 
 case $OSTYPE in
 "linux-gnu"*)


### PR DESCRIPTION
If a user has overriden the build target directory, the outputs won't be in the the ./target folder

Specifying the specific target directory here ensures this script works as expected regardless of user configuration globally