### PR TITLE
Apple specific flags in .cargo/config.toml

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,12 @@
+[target.x86_64-apple-darwin]
+rustflags = [
+    "-C", "link-arg=-undefined",
+    "-C", "link-arg=dynamic_lookup",
+]
+
+[target.aarch64-apple-darwin]
+rustflags = [
+    "-C", "link-arg=-undefined",
+    "-C", "link-arg=dynamic_lookup",
+]
+

--- a/README.md
+++ b/README.md
@@ -4,24 +4,6 @@ This crate provides json5 deserialization for luajit.
 
 Inspired and adapted from [json5-rs](https://github.com/callum-oakley/json5-rs)
 
-**NOTE**: When compiling for macos, please add this to your `$CARGO_HOME/config`
-per [this article](https://blog.kdheepak.com/loading-a-rust-library-as-a-lua-module-in-neovim.html)
-(which also inspired this project):
-
-```TOML
-[target.x86_64-apple-darwin]
-rustflags = [
-    "-C", "link-arg=-undefined",
-    "-C", "link-arg=dynamic_lookup",
-]
-
-[target.aarch64-apple-darwin]
-rustflags = [
-    "-C", "link-arg=-undefined",
-    "-C", "link-arg=dynamic_lookup",
-]
-```
-
 Also, if you haven't already, add ';?.dylib' to your `package.cpath` so it will
 be recognized by the interpreter.
 
@@ -54,6 +36,15 @@ use {
     -- if you're on windows
     -- run = 'powershell ./install.ps1'
     run = './install.sh'
+}
+```
+
+Using [lazy.nvim](https://github.com/folke/lazy.nvim.git)
+
+```lua
+{ 
+    'Joakker/lua-json5',
+    build = './install.sh',
 }
 ```
 


### PR DESCRIPTION
- Using the repo .cargo/config.toml file means the user doesn't need to se these globally and they will be applied by default on a cargo build for macOS as desired
- Removing the documentation about this from the README as it will be applied through cargo
- Adding in lazy package manager setup on README