### PR TITLE
Add support for CARGO_TARGET_DIR

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -1,2 +1,4 @@
-cargo build --features luajit --release
-mv .\target\release\lua_json5.dll lua\json5.dll
+$TARGET_DIR = if ($env:CARGO_TARGET_DIR) { $env:CARGO_TARGET_DIR } else { "target" }
+
+cargo build --features luajit --release --target-dir "$TARGET_DIR"
+Move-Item -Path "$TARGET_DIR\release\lua_json5.dll" -Destination lua\json5.dll

--- a/install.sh
+++ b/install.sh
@@ -1,15 +1,17 @@
 #!/usr/bin/env bash
 
-cargo build --features luajit --release --target-dir ./target
+TARGET_DIR=${CARGO_TARGET_DIR:-target}
+
+cargo build --features luajit --release --target-dir "$TARGET_DIR"
 
 case $OSTYPE in
 "linux-gnu"*)
-	mv ./target/release/liblua_json5.so lua/json5.so
+	mv "$TARGET_DIR"/release/liblua_json5.so lua/json5.so
 	strip lua/json5.so
 	;;
 "darwin"*)
 	# Provide both just in case
-	cp ./target/release/liblua_json5.dylib lua/json5.dylib
+	cp "$TARGET_DIR"/release/liblua_json5.dylib lua/json5.dylib
 	cp lua/json5.dylib lua/json5.so
 	;;
 esac


### PR DESCRIPTION
Hi, since the commit ebc4cb1 the build folder is hardcoded. This means that the crate builds fine regardless of the environment but also that it dumps 100+ MiB into a random folder. This is an issue for some setups where the user went to such lengths as using the custom cargo build folder.

This PR adds a better support for custom target folders by checking the `CARGO_TARGET_DIR` environment variable